### PR TITLE
fastapi depends on starlette. Upgraded the versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ email_validator==2.1.1
 exceptiongroup==1.2.0
 factory-boy==3.3.0
 Faker==24.4.0
-fastapi==0.110.0
+fastapi==0.115.5
 greenlet==3.0.3
 gunicorn==22.0.0
 h11==0.14.0


### PR DESCRIPTION
fastapi depends on starlette. Upgraded the versions
Used 0.115.5 version to loosen the restrictions on starlette.