### PR TITLE
admin role downgrade during email verification

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -170,7 +170,8 @@ class UserService:
         if user and user.verification_token == token:
             user.email_verified = True
             user.verification_token = None  # Clear the token once used
-            user.role = UserRole.AUTHENTICATED
+            if user.role == UserRole.ANONYMOUS:
+                user.role = UserRole.AUTHENTICATED  
             session.add(user)
             await session.commit()
             return True


### PR DESCRIPTION
Fixes #7 
Added a conditional check to ensure the user's role is only updated to AUTHENTICATED if their current role is ANONYMOUS.
This prevents overwriting roles for users who already have higher permissions, preserving role integrity during email verification.