### PR TITLE
Password validation

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -45,6 +45,25 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., example="Secure*1234")
+    @validator('password')
+    def validate_password_strength(cls, password):
+        errors = []
+
+        if len(password) < 8:
+            errors.append("Password must be at least 8 characters long.")
+        if not any(char.isupper() for char in password):
+            errors.append("Password must include at least one uppercase letter.")
+        if not any(char.islower() for char in password):
+            errors.append("Password must include at least one lowercase letter.")
+        if not any(char.isdigit() for char in password):
+            errors.append("Password must include at least one number.")
+        if not any(char in "!@#$%^&*(),.?\":{}|<>" for char in password):
+            errors.append("Password must include at least one special character (!@#$%^&*(),.?\":{}|<>).")
+
+        if errors:
+            raise ValueError(" ".join(errors)) 
+
+        return password
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ rsa==4.9
 six==1.16.0
 sniffio==1.3.1
 SQLAlchemy==2.0.29
-starlette==0.40.0
+starlette==0.41.3
 tomli==2.0.1
 typing_extensions==4.10.0
 uvicorn==0.29.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from builtins import Exception, range, str
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
+import uuid
 
 # Third-party imports
 import pytest
@@ -238,3 +239,13 @@ def email_service():
         mock_service.send_verification_email.return_value = None
         mock_service.send_user_email.return_value = None
         return mock_service
+
+@pytest.fixture
+def unique_user_data():
+    return {
+        "nickname": f"user_{uuid.uuid4().hex[:8]}",
+        "email": f"user_{uuid.uuid4().hex[:8]}@example.com",
+        "first_name": "Test",
+        "last_name": "User",
+        "role": "AUTHENTICATED"
+    }

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -108,3 +108,26 @@ def test_user_base_url_invalid(url, user_base_data):
     user_base_data["profile_picture_url"] = url
     with pytest.raises(ValidationError):
         UserBase(**user_base_data)
+
+@pytest.mark.parametrize("password, expected_error", [
+    ("weakpass", "Password must include at least one uppercase letter."),
+    ("SHORT1!", "Password must include at least one lowercase letter."),
+    ("nouppercase123!", "Password must include at least one uppercase letter."),
+    ("NOLOWERCASE123!", "Password must include at least one lowercase letter."),
+    ("NoNumber!", "Password must include at least one number."),
+    ("NoSpecialChar123", "Password must include at least one special character"),
+])
+def test_user_create_password_invalid(password, expected_error, user_create_data):
+    user_create_data["password"] = password
+    with pytest.raises(ValidationError) as exc_info:
+        UserCreate(**user_create_data)
+    assert expected_error in str(exc_info.value)
+
+@pytest.fixture
+async def users_with_same_role_50_users(db_session, unique_user_data):
+    users = [
+        unique_user_data for _ in range(50)  # Ensures unique data for all users
+    ]
+    db_session.add_all(users)
+    await db_session.commit()
+    return users


### PR DESCRIPTION
Fixes #12 
Introduced a custom validator in the UserCreate model to enforce password strength rules.
The validator ensures that passwords:
Are at least 8 characters long.
Contain at least one uppercase letter, one lowercase letter, one digit, and one special character.
Weak passwords now raise a ValueError with appropriate error messages.