### PR TITLE
Profile Picture Upload using minio

### DIFF
--- a/app/utils/image_uploader.py
+++ b/app/utils/image_uploader.py
@@ -1,0 +1,53 @@
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from minio import Minio
+from minio.error import S3Error
+import os
+from builtins import str
+from uuid import UUID
+from settings.config import settings
+from PIL import Image
+from io import BytesIO
+minio_client = Minio(
+    settings.MINIO_ENDPOINT,
+    access_key=settings.MINIO_ACCESS_KEY,
+    secret_key=settings.MINIO_SECRET_KEY,
+    secure=False
+)
+ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg'}
+MAX_FILE_SIZE = 10 * 1024 * 1024 
+async def upload(file : UploadFile,user_id:UUID) -> str:
+    try:
+            # Save the uploaded file to a temporary directory
+        # p = read_index()
+        
+        file_path = f"/tmp/{file.filename}"
+        size = (200, 200)  # New size: width = 200, height = 200
+        with open(file_path, "wb") as buffer:
+            buffer.write(await file.read())
+        resized_image_data = resize_image(file_path, size,user_id)
+        print(resized_image_data)
+        
+        image_name = str(user_id)+"."+file.filename.split('.')[1]
+        # Upload the file to Minio
+        minio_client.fput_object(settings.MINIO_BUCKET_NAME, image_name, resized_image_data)
+        # Remove the temporary file
+        os.remove(file_path)
+        os.remove(resized_image_data)
+        # Return success response
+        return "http://localhost:9000/"+settings.MINIO_BUCKET_NAME+"/"+image_name
+    except S3Error as exc:
+        print("error occurred.", exc)
+        return None
+def allowed_file(file:UploadFile):
+    filename = file.filename
+    """Check if the file has allowed extension"""
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+def resize_image(image, size,user_id):
+    with Image.open(image) as img:
+        resized_img = img.resize(size)
+        # Convert image to bytes
+        output_path = f"/tmp/{str(user_id)+"."+image.split('.')[1]}"
+        resized_img.save(output_path)
+        return output_path

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,26 @@ services:
     networks:
       - app-network
 
+  minio:
+    image: minio/minio
+    container_name: minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: miniopassword
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9001"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    networks:
+      - app-network
+
   pgadmin:
     image: dpage/pgadmin4
     environment:
@@ -54,6 +74,7 @@ services:
 volumes:
   postgres-data:
   pgadmin-data:
+  minio_data:
 
 networks:
   app-network:

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ httpcore==1.0.5
 httpx==0.27.0
 idna==3.6
 iniconfig==2.0.0
+minio==7.2.7
 Mako==1.3.2
 MarkupSafe==2.1.5
 packaging==24.0
@@ -61,3 +62,4 @@ uvicorn==0.29.0
 validators==0.24.0
 markdown2
 pyjwt
+Pillow

--- a/settings/config.py
+++ b/settings/config.py
@@ -40,6 +40,11 @@ class Settings(BaseSettings):
     smtp_port: int = Field(default=2525, description="SMTP port for sending emails")
     smtp_username: str = Field(default='your-mailtrap-username', description="Username for SMTP server")
     smtp_password: str = Field(default='your-mailtrap-password', description="Password for SMTP server")
+    #Image Storage for Minio
+    MINIO_ENDPOINT : str = Field(default='your-minio-endpoint', description="Endpoint for minio")
+    MINIO_ACCESS_KEY : str = Field(default='yout-minio-access-key', description="Access Key for minio")
+    MINIO_SECRET_KEY : str = Field(default='yout-minio-secret-key', description="Secret Key for minio")
+    MINIO_BUCKET_NAME : str = Field(default='your-minio-bucket-name', description="Bucket Name for minio")
 
 
     class Config:

--- a/tests/test_image_uploader.py
+++ b/tests/test_image_uploader.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+from app.utils.image_uploader import upload, allowed_file, resize_image
+from minio.error import S3Error
+from uuid import uuid4
+from fastapi import UploadFile
+from PIL import Image
+from io import BytesIO
+from unittest.mock import patch, mock_open, MagicMock, call
+from app.dependencies import get_settings
+settings = get_settings()
+
+@pytest.fixture
+def test_image():
+    # Create a test image
+    image = Image.new('RGB', (500, 300), color='red')
+    image.save('/tmp/test_image.jpg')
+    return '/tmp/test_image.jpg'
+
+@pytest.fixture
+def test_file():
+     image = Image.new('RGB', (500, 300), color='red')
+     image.save('/tmp/test_image.jpg')
+     return UploadFile(filename="test_image.jpg", file=BytesIO(image.tobytes()))
+
+@pytest.fixture
+def test_user_id():
+    return uuid4()
+def test_allowed_file():
+    file_data = b"image_data"
+    assert allowed_file(UploadFile(filename="image.png", file=file_data))
+    assert allowed_file(UploadFile(filename="image.jpg", file=file_data))
+    assert allowed_file(UploadFile(filename="image.jpeg", file=file_data))
+    # Test disallowed file extensions
+    assert not allowed_file(UploadFile(filename="image.txt", file=file_data))
+    assert not allowed_file(UploadFile(filename="image.gif", file=file_data))
+def test_resize_image(test_image, test_user_id):
+    resized_image_path = resize_image(test_image, (200, 200), test_user_id)
+    assert os.path.exists(resized_image_path)
+    assert resized_image_path == f"/tmp/{str(test_user_id)}.jpg"
+    os.remove(test_image)
+    os.remove(resized_image_path)
+
+@patch("PIL.Image.open")
+@patch("app.utils.image_uploader.minio_client.fput_object")
+async def test_upload_error(mock_fput_object, mock_image_open, test_file, test_user_id):
+    mock_image = MagicMock(spec=Image.Image)
+    mock_image.resize.return_value = mock_image
+    mock_image_open.return_value = mock_image
+    with patch("builtins.open", mock_open(read_data=b"test image data")), \
+         patch("app.utils.image_uploader.resize_image", return_value="/tmp/resized_test.jpg"), \
+         patch("app.utils.image_uploader.minio_client.fput_object", side_effect=S3Error(code=500, message="S3 error", resource="bucket/object", request_id="request_id", host_id="host_id",response="response")):
+        url = await upload(test_file, test_user_id)
+        assert url is None
+
+@patch("PIL.Image.open")
+@patch("app.utils.image_uploader.minio_client.fput_object")
+@patch("os.remove")  # Mock os.remove
+async def test_upload(mock_os_remove, mock_fput_object, mock_image_open, test_file, test_user_id):
+    mock_image = MagicMock(spec=Image.Image)
+    mock_image.resize.return_value = mock_image
+    mock_image_open.return_value = mock_image
+
+    with patch("builtins.open", mock_open(read_data=b"test image data")), \
+         patch("app.utils.image_uploader.resize_image", return_value="/tmp/resized_test.jpg"):
+        url = await upload(test_file, test_user_id)
+
+        assert url == f"http://localhost:9000/{settings.MINIO_BUCKET_NAME}/{str(test_user_id)}.jpg"
+        mock_fput_object.assert_called_with(settings.MINIO_BUCKET_NAME, f"{str(test_user_id)}.jpg", "/tmp/resized_test.jpg")
+        
+        # Correctly check both os.remove calls
+        mock_os_remove.assert_has_calls([
+            call("/tmp/test_image.jpg"),  # Use 'call' here
+            call("/tmp/resized_test.jpg")
+        ], any_order=True)


### PR DESCRIPTION
Added an API endpoint to allow users to upload and update their profile pictures.
Integrated Minio for secure storage of uploaded profile pictures.
Enhanced the user profile schema and database model to include a field for the profile picture URL.
Included validation to allow only specific image formats (JPG, PNG, JPEG) and optimized uploaded images by resizing them to a standard size.
Updated user profile retrieval functionality to include the profile picture URL. Fixes #17 