### PR TITLE
Multiple nickname failure

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -88,6 +88,13 @@ async def update_user(user_id: UUID, user_update: UserUpdate, request: Request, 
     - **user_update**: UserUpdate model with updated user information.
     """
     user_data = user_update.model_dump(exclude_unset=True)
+    existing_user = await UserService.get_by_email(db, user_update.email)
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already exists")
+
+    existing_user_nickname = await UserService.get_by_nickname(db, user_update.nickname)
+    if existing_user_nickname:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nickname already exists")
     updated_user = await UserService.update(db, user_id, user_data)
     if not updated_user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -79,34 +79,47 @@ class UserService:
         except ValidationError as e:
             logger.error(f"Validation error during user creation: {e}")
             return None
-
     @classmethod
     async def update(cls, session: AsyncSession, user_id: UUID, update_data: Dict[str, str]) -> Optional[User]:
         try:
-            # validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
             validated_data = UserUpdate(**update_data).model_dump(exclude_unset=True)
-            existing_user = await cls.get_by_email(session, validated_data['email'])
-            if existing_user:
-                logger.error("User with given email already exists.")
-                return None
-            existing_user_nickname = await cls.get_by_nickname(session, validated_data['nickname'])
-            if existing_user_nickname:
-                logger.error("User with given nickname already exists.")
-                return None  
+            
+            # Check email uniqueness excluding the current user
+            if "email" in validated_data:
+                existing_user = await cls.get_by_email(session, validated_data["email"])
+                if existing_user and existing_user.id != user_id:
+                    logger.error("User with given email already exists.")
+                    return None
 
-            if 'password' in validated_data:
-                validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
-            query = update(User).where(User.id == user_id).values(**validated_data).execution_options(synchronize_session="fetch")
+            # Check nickname uniqueness excluding the current user
+            if "nickname" in validated_data:
+                existing_user_nickname = await cls.get_by_nickname(session, validated_data["nickname"])
+                if existing_user_nickname and existing_user_nickname.id != user_id:
+                    logger.error("User with given nickname already exists.")
+                    return None  
+
+            # Update password if provided
+            if "password" in validated_data:
+                validated_data["hashed_password"] = hash_password(validated_data.pop("password"))
+
+            # Perform the update
+            query = (
+                update(User)
+                .where(User.id == user_id)
+                .values(**validated_data)
+                .execution_options(synchronize_session="fetch")
+            )
             await cls._execute_query(session, query)
+
             updated_user = await cls.get_by_id(session, user_id)
             if updated_user:
-                session.refresh(updated_user)  # Explicitly refresh the updated user object
+                session.refresh(updated_user)
                 logger.info(f"User {user_id} updated successfully.")
                 return updated_user
-            else:
-                logger.error(f"User {user_id} not found after update attempt.")
+
+            logger.error(f"User {user_id} not found after update attempt.")
             return None
-        except Exception as e:  # Broad exception handling for debugging
+        except Exception as e:
             logger.error(f"Error during user update: {e}")
             return None
 

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -85,6 +85,14 @@ class UserService:
         try:
             # validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
             validated_data = UserUpdate(**update_data).model_dump(exclude_unset=True)
+            existing_user = await cls.get_by_email(session, validated_data['email'])
+            if existing_user:
+                logger.error("User with given email already exists.")
+                return None
+            existing_user_nickname = await cls.get_by_nickname(session, validated_data['nickname'])
+            if existing_user_nickname:
+                logger.error("User with given nickname already exists.")
+                return None  
 
             if 'password' in validated_data:
                 validated_data['hashed_password'] = hash_password(validated_data.pop('password'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ Fixtures:
 
 # Standard library imports
 from builtins import Exception, range, str
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 import uuid
@@ -249,3 +249,20 @@ def unique_user_data():
         "last_name": "User",
         "role": "AUTHENTICATED"
     }
+
+@pytest.fixture
+async def test_user(db_session):
+    user = User(
+        id=uuid.uuid4(),
+        nickname="test_user",
+        email="testuser@example.com",
+        role=UserRole.AUTHENTICATED,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    hashed_password = hash_password("password123")
+    user.hashed_password = hashed_password 
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -62,3 +62,18 @@ async def test_update_professional_status(db_session, verified_user):
     updated_user = result.scalars().first()
     assert updated_user.is_professional
     assert updated_user.professional_status_updated_at is not None
+
+@pytest.fixture
+async def test_user(db_session):
+    """Fixture to create and return a test user."""
+    user = User(
+        id=str(uuid.uuid4()),
+        email="test_user@example.com",
+        nickname="test_user",
+        hashed_password=hash_password("MySuperPassword$1234"),
+        role="AUTHENTICATED"
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -70,7 +70,7 @@ async def test_update_user_valid_data(db_session, user):
 
 # Test updating a user with invalid data
 async def test_update_user_invalid_data(db_session, user):
-    updated_user = await UserService.update(db_session, user.id, {"email": "invalidemail"})
+    updated_user = await UserService.update(db_session, user.id, {"email": new_email, "nickname": "new_nickname"})
     assert updated_user is None
 
 # Test deleting a user who exists

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -5,6 +5,7 @@ from app.dependencies import get_settings
 from app.models.user_model import User, UserRole
 from app.services.user_service import UserService
 from app.utils.nickname_gen import generate_nickname
+from app.utils.security import hash_password
 
 pytestmark = pytest.mark.asyncio
 
@@ -61,17 +62,30 @@ async def test_get_by_email_user_does_not_exist(db_session):
     retrieved_user = await UserService.get_by_email(db_session, "non_existent_email@example.com")
     assert retrieved_user is None
 
-# Test updating a user with valid data
 async def test_update_user_valid_data(db_session, user):
     new_email = "updated_email@example.com"
-    updated_user = await UserService.update(db_session, user.id, {"email": new_email})
+    update_data = {"email": new_email, "nickname": user.nickname or generate_nickname()}
+    updated_user = await UserService.update(db_session, user.id, update_data)
     assert updated_user is not None
     assert updated_user.email == new_email
 
 # Test updating a user with invalid data
 async def test_update_user_invalid_data(db_session, user):
-    updated_user = await UserService.update(db_session, user.id, {"email": new_email, "nickname": "new_nickname"})
-    assert updated_user is None
+    new_email = "invalid_email@example.com"
+    # Add another user with the same nickname to create a conflict
+    conflicting_user = User(
+        nickname="conflicting_nickname",
+        email="existing_user@example.com",
+        hashed_password=hash_password("Secure*1234!"),
+        role=UserRole.AUTHENTICATED,
+    )
+    db_session.add(conflicting_user)
+    await db_session.commit()
+
+    # Attempt to update with conflicting nickname
+    updated_user = await UserService.update(db_session, user.id, {"email": new_email, "nickname": conflicting_user.nickname})
+    assert updated_user is None, "User update should fail due to duplicate nickname"
+
 
 # Test deleting a user who exists
 async def test_delete_user_exists(db_session, user):


### PR DESCRIPTION
Modified the update method to exclude the current user during validation for duplicate emails and nicknames.
Fixes #15 

